### PR TITLE
add basic combat components + system

### DIFF
--- a/assets/textures/spritesheet.atlas
+++ b/assets/textures/spritesheet.atlas
@@ -14,14 +14,16 @@
                 31,
                 32
             ],
-            "frameTime": 0.2
+            "frameTime": 0.2,
+            "loop": true
         },
         "Walk": {
             "frames": [
                 5,
                 6
             ],
-            "frameTime": 0.2
+            "frameTime": 0.2,
+            "loop": true
         },
         "Run": {
             "frames": [
@@ -29,13 +31,22 @@
                 16,
                 17
             ],
-            "frameTime": 0.2
+            "frameTime": 0.2,
+            "loop": true
         },
         "Jump": {
             "frames": [
                 14
             ],
-            "frameTime": 0.2
+            "frameTime": 0.2,
+            "loop": true
+        },
+        "Attack": {
+            "frames": [
+                22
+            ],
+            "frameTime": 0.6,
+            "loop": false
         }
     },
     "atlas": [

--- a/engine/include/spritesheet.hpp
+++ b/engine/include/spritesheet.hpp
@@ -12,9 +12,11 @@ struct SpriteAnimation {
   std::vector<int> frames;
   float frameTime;
   glm::vec2 dimensions;
+  bool loop;
   SpriteAnimation(std::vector<int> frames, float frameTime,
-                  glm::vec2 dimensions)
-      : frames(frames), frameTime(frameTime), dimensions(dimensions) {}
+                  glm::vec2 dimensions, bool loop)
+      : frames(frames), frameTime(frameTime), dimensions(dimensions),
+        loop(loop) {}
   SpriteAnimation() : frames({0}), frameTime(0.0f), dimensions(glm::vec2(0)) {}
 };
 

--- a/engine/src/spritesheet.cpp
+++ b/engine/src/spritesheet.cpp
@@ -71,16 +71,18 @@ void SpriteSheet::loadAtlas(const char *atlasPath) {
   for (auto &animation : animations.items()) {
     const std::string name = animation.key();
     const std::vector<int> frames = animation.value()["frames"];
-    float frameTime = animation.value()["frameTime"];
+    const float frameTime = animation.value()["frameTime"];
+    const bool loop = animation.value()["loop"];
 
     // get the wh (dimensions) of the first frame
 
     const glm::vec4 rect = this->GetAtlasRect(frames[0]);
     const glm::vec2 dimensions = glm::vec2(rect.z, rect.w);
 
-    this->animations[name] = SpriteAnimation(frames, frameTime, dimensions);
+    this->animations[name] =
+        SpriteAnimation(frames, frameTime, dimensions, loop);
   }
   const glm::vec4 rect = this->GetAtlasRect(0);
   const glm::vec2 dimensions = glm::vec2(rect.z, rect.w);
-  this->animations["default"] = SpriteAnimation({0}, 0.0f, dimensions);
+  this->animations["default"] = SpriteAnimation({0}, 0.0f, dimensions, false);
 }

--- a/game/include/components.hpp
+++ b/game/include/components.hpp
@@ -10,12 +10,15 @@ struct Transform2D {
   glm::vec2 position;
   glm::vec2 scale;
   float rotation;
+  glm::vec2 global_position;
 
   Transform2D(glm::vec2 position, glm::vec2 scale, float rotation)
-      : position(position), scale(scale), rotation(rotation) {}
+      : position(position), scale(scale), rotation(rotation),
+        global_position(position) {}
 
   Transform2D()
-      : position(glm::vec2(0, 0)), scale(glm::vec2(1, 1)), rotation(0) {}
+      : position(glm::vec2(0, 0)), scale(glm::vec2(1, 1)), rotation(0),
+        global_position(position) {}
 
   Transform2D WithPosition(glm::vec2 position) {
     this->position = position;
@@ -42,6 +45,7 @@ struct AnimatedSprite {
   float currentTime;
   int currentFrame;
   SpriteAnimation *currentAnimation;
+  bool isAnimationFinished;
 
   void SetAnimation(SpriteAnimation *animation) {
     if (this->currentAnimation == animation) {
@@ -50,12 +54,13 @@ struct AnimatedSprite {
     this->currentAnimation = animation;
     this->currentFrame = 0;
     this->currentTime = 0;
+    this->isAnimationFinished = false;
   };
 
   AnimatedSprite(std::shared_ptr<SpriteSheet> spriteSheet,
                  SpriteAnimation *animation)
       : spriteSheet(spriteSheet), currentTime(0), currentFrame(0),
-        currentAnimation(animation) {}
+        currentAnimation(animation), isAnimationFinished(false) {}
 
   AnimatedSprite()
       : spriteSheet(nullptr), currentTime(0), currentFrame(0),
@@ -64,19 +69,22 @@ struct AnimatedSprite {
 
 struct Player {
   std::string name;
+  bool isAttacking; // @TODO move to child collider
 };
 
 struct Camera {
   glm::vec2 position;
 };
 
-enum class ColliderType { TRIGGER, SOLID };
+enum class ColliderType { TRIGGER, SOLID, HURTBOX };
 
 struct Collider {
   // collider vertices
   glm::vec4 vertices;
   ColliderType type;
   bool isGrounded;
+  bool flipX;
+  bool active;
 };
 
 struct Velocity {

--- a/game/include/components.hpp
+++ b/game/include/components.hpp
@@ -76,15 +76,25 @@ struct Camera {
   glm::vec2 position;
 };
 
-enum class ColliderType { TRIGGER, SOLID, HURTBOX };
-
-struct Collider {
-  // collider vertices
-  glm::vec4 vertices;
-  ColliderType type;
+struct Groundable {
   bool isGrounded;
-  bool flipX;
+};
+
+struct CollisionVolume {
+  glm::vec4 vertices;
+};
+
+struct PhysicsBody {};
+
+struct StaticBody {};
+
+struct Hurtbox {
+  float damage;
   bool active;
+};
+
+struct Health {
+  float value;
 };
 
 struct Velocity {

--- a/game/include/game.hpp
+++ b/game/include/game.hpp
@@ -10,6 +10,15 @@
 #include <texture.hpp>
 #include <tilemap.hpp>
 
+struct CollisionEvent {
+  flecs::entity entity1;
+  flecs::entity entity2;
+  Transform2D *transform1;
+  Transform2D *transform2;
+  CollisionVolume *collisionVolume1;
+  CollisionVolume *collisionVolume2;
+};
+
 class Game {
 public:
   Game();

--- a/game/include/game.hpp
+++ b/game/include/game.hpp
@@ -20,7 +20,7 @@ public:
   int close();
 
   void push_rect_transform(const SDL_Rect &rect, const SDL_Rect &pushedBy,
-                           Transform2D &t1, Collider &c1);
+                           Transform2D &t1, CollisionVolume &c1);
 
   std::unique_ptr<SpriteBatch> spriteBatcher;
   std::shared_ptr<Texture> textureTink;


### PR DESCRIPTION
1. Added new components to better organize systems.
2. Entity Collisions now resolve based on component type
3. First pass implementation of parent child transformations (only global position is accumulated)
4. Player Hurtbox is a child of the player (I think there is a better way to do the lookup, but it works for now!

[combat.webm](https://github.com/NotoriousENG/gl_game/assets/32341612/a9f6c0c0-5930-443a-8d81-2a5794ba1f19)
